### PR TITLE
Defined choices for the 'boot' parameter

### DIFF
--- a/library/kld
+++ b/library/kld
@@ -149,7 +149,8 @@ def main():
                 choices = [ True, False ]
             ),
             boot = dict(
-                default = True
+                default = True,
+                choices = [ True, False ]
             )
         ),
     )


### PR DESCRIPTION
Tiny change to restrict values to match the restrictions outlined in loader.conf(5)
