### PR TITLE
remove choices=BOOLEANS for compatibility with ansible 2.5

### DIFF
--- a/library/kld
+++ b/library/kld
@@ -146,13 +146,11 @@ def main():
             ),
             load = dict(
                 default = True,
-                type    = 'bool',
-                choices = BOOLEANS
+                type    = 'bool'
             ),
             boot = dict(
                 default = True,
-                type    = 'bool',
-                choices = BOOLEANS
+                type    = 'bool'
             )
         ),
     )


### PR DESCRIPTION
I had the following error with ansible 2.5:
    
    NameError: global name 'BOOLEANS' is not defined

It was removed in [this commit](https://github.com/ansible/ansible/commit/2f36b9e5ce0ec41a822752845d3b7c4afdf7eee9).