### PR TITLE
Add empty meta file

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,3 @@
+---
+
+dependencies: []


### PR DESCRIPTION
This will allow ansible-galaxy to consider it a role, which makes it available to `ansible-galaxy install -r requirements.yml` using

```
#requirements.yml
- src: https://github.com/dlundgren/ansible-freebsd-modules```

and pulling it in to role dependencies via
```
#roles/bla/meta/main.yml
dependencies:
- role: ansible-freebsd-modules
```

