### PR TITLE
Variables never added to loader.conf, exists fails, needs to scan err for expected message

### DIFF
--- a/library/kld
+++ b/library/kld
@@ -79,7 +79,8 @@ class FreeBSDKernelModule(object):
         # sysrc doesn't really use exit codes
         (rc, out, err) = self.module.run_command("%s -f /boot/loader.conf %s_load" %( self.sysrc, self.name ))
         
-        if out.find("unknown variable") == -1:
+        # Message comes out on err...
+        if err.find("unknown variable") == -1:
             return True
         else:
             return False


### PR DESCRIPTION
My scripts were never updating `/boot/loader.conf`.  Tracked it down to the `exists` method not doing what you intended because the anticipated message is in the stderr stream, not the stdout.

[On FreeBSD 12_0...] If you call

```shell
sysrc -f /boot/loader.conf blort_load
```

and blort_load isn't in the file, the error message that contains the 'unknown variable' string that we search for is written to the `err` stream:

```
$ cat /boot/loader.conf
debug.trace_on_panic=1
debug.debugger_on_panic=0
kern.panic_reboot_wait_time=0
autoboot_delay="-1"
beastie_disable="YES"
hint.atkbd.0.disabled=1
hint.atkbdc.0.disabled=1
boot_multicons="YES"
hw.broken_txfifo="1"
if_ena_load="YES"
zfs_load="YES"
kern.geom.label.disk_ident.enable="0"
kern.geom.label.gptid.enable="0"
$ sudo sysrc -f /boot/loader.conf blort_load 2>stderror 1>stdout
$ cat stderror
sysrc: unknown variable 'blort_load'
$ cat stdout
$
```